### PR TITLE
Add spacing to VStack in InternalWrappingHStack

### DIFF
--- a/Sources/WrappingHStack/InternalWrappingHStack.swift
+++ b/Sources/WrappingHStack/InternalWrappingHStack.swift
@@ -69,7 +69,7 @@ struct InternalWrappingHStack: View {
     }
     
     var body: some View {
-        VStack(alignment: alignment, spacing: 0) {
+        VStack(alignment: alignment, spacing: spacing.verticalSpacing) {
             ForEach(0 ..< totalLanes, id: \.self) { laneIndex in               
                 HStack(spacing: 0) {
                     if alignment == .center || alignment == .trailing, shouldHaveSideSpacers(lane: laneIndex) {
@@ -88,7 +88,7 @@ struct InternalWrappingHStack: View {
                         }
                         
                         if endOf(lane: laneIndex) != $0 {
-                            if case .constant(let exactSpacing) = spacing {
+                            if case .constant(let exactSpacing, _) = spacing {
                                 Spacer(minLength: 0)
                                     .frame(width: exactSpacing)
                             } else {

--- a/Sources/WrappingHStack/WrappingHStack.swift
+++ b/Sources/WrappingHStack/WrappingHStack.swift
@@ -29,18 +29,27 @@ public struct WrappingHStack: View {
     }
     
     public enum Spacing {
-        case constant(CGFloat)
-        case dynamic(minSpacing: CGFloat)
-        case dynamicIncludingBorders(minSpacing: CGFloat)
+        case constant(_ horizontal: CGFloat, vertical: CGFloat = 0)
+        case dynamic(minSpacing: CGFloat, vertical: CGFloat = 0)
+        case dynamicIncludingBorders(minSpacing: CGFloat, vertical: CGFloat = 0)
         
         internal var estimatedSpacing: CGFloat {
             switch self {
-            case .constant(let constantSpacing):
+            case .constant(let constantSpacing, _):
                 return constantSpacing
-            case .dynamic(minSpacing: let minSpacing), .dynamicIncludingBorders(minSpacing: let minSpacing):
+            case .dynamic(minSpacing: let minSpacing, _), .dynamicIncludingBorders(minSpacing: let minSpacing, _):
                 return minSpacing
             }
         }
+
+      internal var verticalSpacing: CGFloat {
+          switch self {
+          case .constant(_, vertical: let verticalSpacing),
+              .dynamic(_, vertical: let verticalSpacing),
+              .dynamicIncludingBorders(_, vertical: let verticalSpacing):
+              return verticalSpacing
+          }
+      }
     }
     
     let items: [ViewType]


### PR DESCRIPTION
Not to handle neighbor components because of padding of items, I added spacing to VStack in InternalWrappingHStack.

- Add `verticalSpacing` input to `Spacing` enum of WrappingHStack.
- Because of default value of verticalSpacing, this is not a breaking change for existing users. You can see there is no problem with example view who doesn't have verticalSpacing like before.