### PR TITLE
Prevent multiple CGFloatPreferenceKey tried to updates per frame

### DIFF
--- a/Sources/WrappingHStack/WrappingHStack.swift
+++ b/Sources/WrappingHStack/WrappingHStack.swift
@@ -69,7 +69,9 @@ public struct WrappingHStack: View {
         }
         .frame(height: height)
         .onPreferenceChange(CGFloatPreferenceKey.self, perform: {
-            height = $0
+            if abs(height - $0) > 1 {
+                height = $0
+            }
         })
     }
 }


### PR DESCRIPTION
Threshold on onPreferenceChange prevents multiple "Bound preference CGFloatPreferenceKey tried to update multiple times per frame." warnings when having multiple WrappingHStack on a ScrollView and reduces jittery scroll