### PR TITLE
Exclude Example projects in Swift Package Manager

### DIFF
--- a/WrappingHStackExample-OSX/Package.swift
+++ b/WrappingHStackExample-OSX/Package.swift
@@ -1,0 +1,6 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package()

--- a/WrappingHStackExample-iOS/Package.swift
+++ b/WrappingHStackExample-iOS/Package.swift
@@ -1,0 +1,6 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package()


### PR DESCRIPTION
## Motivation

When using Swift Package Manager, it clones both `WrappingHStackExample-iOS` and `WrappingHStackExample-OSX` when you want to use the package.
However, these example codes are not necessary as dependencies for the main functionality.

In contrast, when using CocoaPods, Example projects are not included.
https://github.com/dkk/WrappingHStack/blob/f31b8fdc57759c5aa5fc98c70746db5556e73300/WrappingHStack.podspec#L18

## Resolved solution

Currently, Swift Package Manager [`exclude`](https://developer.apple.com/documentation/packagedescription/target/exclude) allows specifying individual files, but it doesn't provide a way to exclude directories.
As a workaround, I added `Package.swift` to the Example projects directory to prevent them from being included when using the package.
https://stackoverflow.com/questions/69382302/swift-package-how-to-exclude-files-in-root-git-directory-from-the-actual-swift/70990534#70990534

| Before | After (yutailang0119:swiftpm/exclude-example) |
|--------|--------|
| <img width="1512" alt="image" src="https://github.com/dkk/WrappingHStack/assets/9477376/81538d13-64d5-42a2-9451-d5da0c800cc8"> | <img width="1512" alt="image" src="https://github.com/dkk/WrappingHStack/assets/9477376/f106d9a1-bbf7-4bef-a1b3-c3e87bf017e5"> |

## Side effect

There is one problem with this approach: when you open `WrappingHStack/Package.swift` in Xcode, it doesn't display the Example projects.

| Before | After (yutailang0119:swiftpm/exclude-example) |
|--------|--------|
| <img width="1512" alt="image" src="https://github.com/dkk/WrappingHStack/assets/9477376/77fbb678-2cbb-4204-a986-c1f452720600"> | <img width="1512" alt="image" src="https://github.com/dkk/WrappingHStack/assets/9477376/fd7aef92-e5a6-4a0b-b0bc-795ca71459f7"> | 