### PR TITLE
use NewLine's in looped WrappedHStacks

### DIFF
--- a/Sources/WrappingHStack/ViewType.swift
+++ b/Sources/WrappingHStack/ViewType.swift
@@ -10,4 +10,28 @@ enum ViewType {
         default: self = .any(AnyView(rawView))
         }
     }
+
+    init<V: View>(conditionalContent: V) {
+        if conditionalContent.isConditionalNewLine() {
+            self = .newLine
+        } else {
+            self.init(rawView: conditionalContent)
+        }
+    }
 }
+
+extension View {
+    /// Hack to find whether or not a view inside a loop-based init is a new-line.
+    /// As opposed to the `TupleView`-based approach of the other init,
+    /// the view returned by `content`in the loop-based init is type-erased as a `_ConditionalContent` type
+    /// unfortunately, we don't have access to any underlying values, so all we can do is evaluate description of `self`
+    /// - Returns: boolean value indicating whether the object is a `NewLine` wrapped in a `_ConditionalContent` struct
+    fileprivate func isConditionalNewLine() -> Bool {
+        String(describing: self).hasPrefix("_ConditionalContent")
+        && ((String(describing: self).contains("<NewLine")
+             && String(describing: self).contains("Storage.trueContent(WrappingHStack.NewLine"))
+            || (String(describing: self).contains("NewLine>")
+                && String(describing: self).contains("Storage.falseContent(WrappingHStack.NewLine")))
+    }
+}
+

--- a/Sources/WrappingHStack/WrappingHStack.swift
+++ b/Sources/WrappingHStack/WrappingHStack.swift
@@ -99,7 +99,7 @@ public extension WrappingHStack {
         self.lineSpacing = lineSpacing
         self.alignment = alignment
         self.contentManager = ContentManager(
-            items: data.map { ViewType(rawView: content($0[keyPath: id])) },
+            items: data.map { ViewType(conditionalContent: content($0[keyPath: id])) },
             getWidths: {
                 data.map {
                     Self.getWidth(of: content($0[keyPath: id]))


### PR DESCRIPTION
Change to address issue #38 - addresses the situation in `ViewType init(rawView:)` where `rawView` is wrapped as a `_ConditionalContent` type (because of the presence of multiple conditional types in a loop's content builder) which causes it to fail the `is NewLine` switch case.